### PR TITLE
build: update java.version to 21 (LTS)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>springboot</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>18</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 <!--		<dependency>-->


### PR DESCRIPTION
## Summary
- Updates `java.version` from 18 to 21 in `pom.xml`
- Java 21 is an LTS release and matches the minimum version in the CI test matrix (21, 23)
- Java 18 is EOL; using 21 keeps the project on a supported LTS version

## Test plan
- [ ] CI should pass with Java 21 and 23 (existing test matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)